### PR TITLE
Improve conversation ID extraction

### DIFF
--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from conv import append_conversations, sort_conversations_file, load_existing_ids
+from conv import (
+    append_conversations,
+    extract_conversation_id,
+    load_existing_ids,
+    sort_conversations_file,
+)
 
 
 def make_conv(cid: str, last: int):
@@ -27,3 +32,30 @@ def test_sorting(tmp_path):
     lines = [json.loads(l) for l in f.read_text(encoding="utf-8").splitlines() if l.strip()]
     # Après tri: b (300), c (200), a (100)
     assert [l["id"] for l in lines] == ["b", "c", "a"]
+
+
+def test_extract_conversation_id_variants():
+    payloads = [
+        {"id": "abc"},
+        {"_id": "def"},
+        {"conversation_id": "ghi"},
+        {"session_id": "jkl"},
+        {"session": {"id": "mno"}},
+        {"conversation": {"conversation_id": "pqr"}},
+        {"meta": {"_id": "stu"}},
+        {"data": {"session": {"session_id": "vwx"}}},
+    ]
+    expected = {"abc", "def", "ghi", "jkl", "mno", "pqr", "stu", "vwx"}
+    assert {extract_conversation_id(p) for p in payloads} == expected
+
+
+def test_load_existing_ids_with_nested_structures(tmp_path):
+    f = tmp_path / "conversations.jsonl"
+    conversations = [
+        {"session": {"id": "sess-1"}},
+        {"meta": {"conversation_id": "meta-2"}},
+        {"data": {"session": {"session_id": "sess-3"}}},
+    ]
+    append_conversations(f, conversations)
+    ids = load_existing_ids(f)
+    assert ids == {"sess-1", "meta-2", "sess-3"}


### PR DESCRIPTION
## Summary
- add a shared helper that extracts Crisp conversation identifiers from multiple payload formats
- guard the exporter against missing requests dependency and reuse the helper for duplicate detection
- expand the unit test suite to cover the new helper and nested identifier cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e66184acb4832c8d584cee4acabde5